### PR TITLE
refactor(build): remove default argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
### Changes
This commit removes the `mode` argument specified. The `mode` argument with the type `OpenTextMode` defaults to read mode, and thus shouldn't be specified.

### Example
| With kwargs | Without kwargs |
|--------|--------|
|  ```open("foo.c", errors=None, newline=None, closefd=True)``` | ```open("foo.c")``` | 
> Both do effectively the same thing