### PR TITLE
bump: increment `requirements.txt` versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,15 @@
-rich==9.8.2
-image-go-nord==0.1.3
+certifi==2025.1.31
+charset-normalizer==3.4.1
+ffmpeg-python==0.2.0
+future==1.0.0
+idna==3.10
+image-go-nord==1.2.0
+markdown-it-py==3.0.0
+mdurl==0.1.2
+numpy==2.2.2
+pillow==11.1.0
+Pygments==2.19.1
+requests==2.32.3
+rich==13.9.4
+setuptools==75.8.0
+urllib3==2.3.0


### PR DESCRIPTION
## Proposed Changes
 1. Incremented `requirements.txt` versions. It should noted that each dependency is completely backwards compatible with past versions of gruvbox-factory.

 2.  Additional dependencies that are required by `requirements.txt` have been added. This is simply a result of analyzing the dependencies with pip using pip freeze[1].

[1]: https://pip.pypa.io/en/stable/cli/pip_freeze/